### PR TITLE
Presentation engine quality-of-life: style doc + --slide flag

### DIFF
--- a/godot/resources/presentation_theme.gd
+++ b/godot/resources/presentation_theme.gd
@@ -7,6 +7,37 @@
 ## Usage:
 ##   $Title.add_theme_font_size_override("font_size", PresentationTheme.TITLE)
 ##   $Body.add_theme_font_size_override("font_size", PresentationTheme.BODY)
+##
+## --- Visual Hierarchy: Style + Structure ---
+##
+## Font size alone does not determine visual prominence. A label's
+## perceived weight depends on:
+##   - The font size (these constants)
+##   - The container's structural padding (cell dimensions, separators)
+##   - The character density of the text itself
+##
+## Example: PT.BODY (28pt) text inside a 220x100 padded grid cell reads
+## comfortably because the cell provides empty space around the text.
+## The same PT.BODY text in a flow-layout VBoxContainer with no fixed
+## cell size reads as small and cramped because there's no padding.
+##
+## When designing a multi-element slide, decide BOTH the font scale
+## (these PT.* constants) AND the structural padding (custom_minimum_size,
+## h_separation, v_separation, separators) together. Reusing PT constants
+## alone will not make two slides feel visually consistent; the
+## surrounding structure has to support the styling.
+##
+## Reference pattern — grid/table layout:
+##   - GridContainer with cells at custom_minimum_size ~(220-480) x 100
+##   - h_separation = v_separation = 12
+##   - BODY text in cells; SUBHEADING for column or row headers
+##   - vertical_alignment = 1 (center) and autowrap_mode = 2 inside cells
+##   Suitable for any number of elements; cells provide the breathing room.
+##
+## Reference pattern — section list:
+##   - VBoxContainer per section, sections side-by-side via offset
+##     positioning. Works for sparse 1-3 line sections. For denser
+##     content (4+ lines per section), switch to the grid pattern.
 class_name PresentationTheme
 
 

--- a/godot/scenes/demos/demo_presentation/PresentationController.gd
+++ b/godot/scenes/demos/demo_presentation/PresentationController.gd
@@ -33,9 +33,14 @@ var _saved_slide: Control = null  # Preserved slide instance for Ctrl+D toggle
 
 
 func _ready():
-	# Command-line: --presentation=followup or --presentation=default
-	# Check both engine args and user args (after --)
+	# Command-line:
+	#   --presentation=<name>  choose which manifest under scratch/presentations
+	#   --slide=<N>            start at slide N (1-indexed); skips advance
+	#                          through slides 1..N-1 for faster iteration on a
+	#                          specific slide during dev/tweak sessions.
+	# Both engine args and user args (after --) are checked.
 	var all_args = OS.get_cmdline_args() + OS.get_cmdline_user_args()
+	var start_slide_index: int = 0
 	for arg in all_args:
 		if arg.begins_with("--presentation="):
 			var pname = arg.get_slice("=", 1)
@@ -45,6 +50,10 @@ func _ready():
 				print("[Presentation] Using manifest: %s" % pname)
 			else:
 				push_warning("[Presentation] Manifest not found: %s" % candidate)
+		elif arg.begins_with("--slide="):
+			var n: int = arg.get_slice("=", 1).to_int()
+			if n > 0:
+				start_slide_index = n - 1  # CLI is 1-indexed; internal is 0-indexed
 
 	if manifest_path.is_empty():
 		# Try default locations
@@ -60,7 +69,13 @@ func _ready():
 		_load_manifest(manifest_path)
 
 	if _slides.size() > 0:
-		_show_slide(0, false)
+		var clamped: int = clamp(start_slide_index, 0, _slides.size() - 1)
+		if clamped != start_slide_index:
+			push_warning("[Presentation] --slide=%d out of range (deck has %d slides); starting at slide %d" %
+				[start_slide_index + 1, _slides.size(), clamped + 1])
+		elif clamped > 0:
+			print("[Presentation] Starting at slide %d (--slide flag)" % (clamped + 1))
+		_show_slide(clamped, false)
 
 	# Hide debug panel by default
 	if debug_panel:


### PR DESCRIPTION
## Summary

Two small presentation-engine quality-of-life improvements that make the slide-tweak loop faster.

### 1. Structure-styling note in `presentation_theme.gd`

Adds a guidance block at the top of `presentation_theme.gd` explaining the relationship between centralized font/color constants and per-slide structural padding. Two slides can both call `add_theme_font_size_override("font_size", PT.BODY)` and look visually inconsistent if one is in a 220×100 padded grid cell and the other is packed into a flow VBox. The PT constants centralize *what* the font size is; they don't centralize *how the text reads in context*.

Documents two reference patterns:

- **Grid/table layout** — `GridContainer` with `custom_minimum_size ~(220-480)×100` cells, `h_separation = v_separation = 12`, `BODY` text in cells, `SUBHEADING` for headers. Works for any element count; cells provide breathing room.
- **Section list** — `VBoxContainer` per section, sections side-by-side via offset positioning. Works for sparse content; switch to grid for denser.

### 2. `--slide=<N>` CLI flag

`PresentationController` now parses an optional `--slide=<N>` command-line argument (1-indexed) and uses it as the starting slide index. Saves the dev iteration round-trip of advancing through slides 1..N-1 every time you want to tweak slide N.

\`\`\`
godot ... -- --presentation=followup --slide=9
\`\`\`

Out-of-range values clamp to the last slide with a `push_warning` so a typo doesn't silently swallow into a no-op.

## Changes

- `godot/resources/presentation_theme.gd` — 31-line guidance comment at the top of the docstring; no constants changed.
- `godot/scenes/demos/demo_presentation/PresentationController.gd` — `+18 / -3` lines: parses `--slide=<N>` in `_ready()`, uses it as the starting index when calling `_show_slide()`.

## Why bundled

Both changes make slide-authoring faster — the doc saves a 'why does this look different?' debugging round-trip; the flag saves the navigation round-trip. They're independent but landed together as 'presentation engine QoL'.

## Test plan

- [x] Smoke test green (`16 OK, 0 FAIL`)
- [x] Verified `--slide=9` lands at slide 9 (log: \`[Presentation] Starting at slide 9 (--slide flag)\`)
- [x] Verified `--slide=99` clamps to last slide with warning

## Branch context

Stacked on \`feat/plugin/15-overlay-subscription-policy\` (PR #17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)